### PR TITLE
Pardot package migration

### DIFF
--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -1,0 +1,28 @@
+with visitor_activity as (
+    select *
+    from {{ ref('stg_pardot__visitor_activity') }}
+),
+
+campaigns as (
+    select *
+    from {{ ref('stg_pardot__campaign') }}
+),
+
+list_emails as (
+    select *
+    from {{ ref('stg_pardot__list_email') }}
+)
+
+select 
+    visitor_activity.*,
+    list_email_name,
+    list_email_subject,
+    list_email_sent_at,
+    campaigns.campaign_name as activity_campaign_name 
+
+from visitor_activity
+
+left join campaigns on visitor_activity.campaign_id = campaigns.campaign_id
+
+left join list_emails on visitor_activity.list_email_id = list_emails.list_email_id
+

--- a/models/intermediate/int_pardot__activities_join_enriched.sql
+++ b/models/intermediate/int_pardot__activities_join_enriched.sql
@@ -15,9 +15,19 @@ list_emails as (
 
 select 
     visitor_activity.*,
+    
+    is_mmus_formated_list_email_name,
+    list_email_natural_key,
+    list_email_sent_at,
+    list_email_keyword_segment,
+    list_email_keyword_status,
+    list_email_keyword_type,
+    list_email_name_parsed_topic,
+
     list_email_name,
     list_email_subject,
-    list_email_sent_at,
+
+    
     campaigns.campaign_name as activity_campaign_name 
 
 from visitor_activity

--- a/models/intermediate/int_pardot__prospects_join_enriched.sql
+++ b/models/intermediate/int_pardot__prospects_join_enriched.sql
@@ -1,0 +1,38 @@
+with pardot_prospects as (
+    select *
+    from {{ ref('stg_pardot__prospect') }}
+),
+
+salesforce_contacts as (
+    select * 
+    from {{ ref('stg_salesforce__contacts') }}
+),
+
+pardot_campaigns as (
+    select 
+        campaign_id,
+        campaign_name,
+        campaign_salesforce_id
+    from {{ ref('stg_pardot__campaign') }}
+),
+
+joined as (
+    select
+        pardot_prospects.prospect_id,
+        
+        prospect_campaigns.campaign_name as prospect_campaign_name,
+        prospect_campaigns.campaign_salesforce_id as prospect_campaign_salesforce_id,
+
+        pardot_prospects.crm_contact_fid,
+        salesforce_contacts.account_id
+    
+    from pardot_prospects
+
+    left join salesforce_contacts
+    on pardot_prospects.crm_contact_fid = salesforce_contacts.contact_id
+
+    left join pardot_campaigns as prospect_campaigns
+    using (campaign_id)
+)
+
+select * from joined

--- a/models/pardot__activities.sql
+++ b/models/pardot__activities.sql
@@ -1,8 +1,6 @@
 with activities as (
-    select 
-    * 
-
-from {{ ref('int_pardot__activities_join_enriched') }}
+    select * 
+    from {{ ref('int_pardot__activities_join_enriched') }}
 ),
 
 prospects as (

--- a/models/pardot__activities.sql
+++ b/models/pardot__activities.sql
@@ -1,0 +1,25 @@
+with activities as (
+    select 
+    * 
+
+from {{ ref('int_pardot__activities_join_enriched') }}
+),
+
+prospects as (
+    select *
+    from {{ ref('int_pardot__prospects_join_enriched') }}  
+),
+
+joined as (
+    select
+        *
+
+    from activities
+
+    left join prospects using (prospect_id)
+)
+
+select
+    *
+
+from joined

--- a/models/pardot__prospects.sql
+++ b/models/pardot__prospects.sql
@@ -8,10 +8,20 @@ with prospects as (
     select *
     from {{ ref('int__activities_by_prospect') }}
 
+), enriched_prospects as (
+
+    select 
+        prospect_id,
+        account_id,
+    from {{ ref('int_pardot__prospects_join_enriched') }}
+
 ), joined as (
 
     select
         prospects.*,
+
+        enriched_prospects.account_id,
+
         {% for event_type in var('prospect_metrics_activity_types') %}
         coalesce(activities.count_activity_{{ event_type|lower|replace(' ','_') }},0) as count_activity_{{ event_type|lower|replace(' ','_') }},
         activities.most_recent_{{ event_type|lower|replace(' ','_') }}_activity_timestamp,
@@ -23,6 +33,8 @@ with prospects as (
         activities.most_recent_email_activity_timestamp
     from prospects
     left join activities
+        using (prospect_id)
+    left join enriched_prospects
         using (prospect_id)
 
 )

--- a/models/pardot__prospects.sql
+++ b/models/pardot__prospects.sql
@@ -12,7 +12,7 @@ with prospects as (
 
     select 
         prospect_id,
-        account_id,
+        account_id
     from {{ ref('int_pardot__prospects_join_enriched') }}
 
 ), joined as (

--- a/packages.yml
+++ b/packages.yml
@@ -1,2 +1,3 @@
 packages:
-  - local: /usr/app/dbt/temp/dbt_pardot_source
+  - git: "https://github.com/theirc/er-analytics-dbt_pardot_source"
+    revision: "main"

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,2 @@
 packages:
-  - package: fivetran/pardot_source
-    version: [">=0.6.0", "<0.7.0"]
+  - local: /usr/app/dbt/temp/dbt_pardot_source


### PR DESCRIPTION
## What this does and why
As part of issue # 1290 on the er-analytics-dbt repo, this issue builds / migrates all models within the fivetran forked `pardot` package on databricks

Models which have been migrated

- [x] `int__opportunity_tmp` (built successfully on Databricks)
- [x] `pardot__activities` (built successfully on Databricks)
- [x] `pardot__campaigns` (built successfully on Databricks)
- [x] `pardot__lists` (built successfully on Databricks)
- [x] `pardot__opportunities` (built successfully on Databricks)
- [x] pardot__prospects (failed on initial build, fixed by removing trailing comma before the FROM clause on a CTE within the model)

note: there are also 5 empheral models which live within the pardot package intermediate folder, which will not be built as models or tested within this PR. These models are listed out below:

- int__activities_by_list
- int__activities_by_prospect
- int__opportunities_by_campaign
- int_pardot__activities_join_enriched
- int_pardot__prospects_join_enriched



## PR type

- [x] Databricks migration

## Related Issues and PRs
[#1290 ](https://github.com/theirc/er-analytics-dbt/issues/1290)

## dbt dev/local run logs

```
(dbt-env-dbx) PS C:\Users\AndrewLo\Repos\er-analytics-dbt> dbt run --select tag:email --exclude pardot_source
13:54:14  Running with dbt=1.9.7
C:\Users\AndrewLo\Repos\er-analytics-dbt\dbt-env-dbx\lib\site-packages\pydantic\_internal\_config.py:373: UserWarning: Valid config keys have changed in V2:
* 'allow_population_by_field_name' has been renamed to 'validate_by_name'
  warnings.warn(message, UserWarning)
  warnings.warn(message, UserWarning)
13:54:15  Registered adapter: databricks=1.9.7
13:54:17  [WARNING]: Configuration paths exist in your dbt_project.yml file which do not apply to any resources.
There are 1 unused configuration paths:
- seeds.er_analytics_dbt.data_processing
13:54:18  Found 236 models, 3 snapshots, 398 data tests, 55 seeds, 223 sources, 2049 macros
13:54:18
13:54:18  Concurrency: 4 threads (target='databricks_local')
13:54:18
13:54:20  1 of 6 START sql view model dbt_andrewlobo_silver_pardot.int__opportunity_tmp .. [RUN]
13:54:20  2 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__opportunities  [RUN]
13:54:20  3 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__activities ... [RUN]
13:54:20  4 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__prospects .... [RUN]
13:54:32  1 of 6 OK created sql view model dbt_andrewlobo_silver_pardot.int__opportunity_tmp  [OK in 12.55s]
13:54:40  5 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__campaigns .... [RUN]
13:55:11  2 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__opportunities  [OK in 51.68s]
13:56:27  5 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__campaigns  [OK in 107.85s]
14:06:26  4 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__prospects  [OK in 726.22s]
14:06:26  6 of 6 START sql table model dbt_andrewlobo_silver_pardot.pardot__lists ........ [RUN]
14:07:20  6 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__lists ... [OK in 53.63s]
14:11:45  3 of 6 OK created sql table model dbt_andrewlobo_silver_pardot.pardot__activities  [OK in 1045.39s]
14:11:48
14:11:48  Finished running 5 table models, 1 view model in 0 hours 17 minutes and 29.35 seconds (1049.35s).
14:11:49
14:11:49  Completed successfully
14:11:49
14:11:49  Done. PASS=6 WARN=0 ERROR=0 SKIP=0 TOTAL=6
```

Screenshot of models on my dev folder on databricks:

<img width="306" height="229" alt="image" src="https://github.com/user-attachments/assets/39153c0b-3ab0-44cd-ac00-d018e02b2804" />
